### PR TITLE
Add a mock interface

### DIFF
--- a/turret_python_interface/interface.py
+++ b/turret_python_interface/interface.py
@@ -34,16 +34,16 @@ class Interface(AbstractContextManager):
             baud: baud rate to communicate with the device
             timeout: serial read timeout, in seconds(?)
         """
-        self.path = serial_path
-        self.baud = baud
-        self.con: Optional[Serial] = None
-        self.timeout = timeout  # presumably in seconds?
+        self._path = serial_path
+        self._baud = baud
+        self._con: Optional[Serial] = None
+        self._timeout = timeout  # presumably in seconds?
 
     def __enter__(self) -> Interface:
-        path = str(self.path.absolute())
-        logger.debug(f"opening serial port {path!r} with baud {self.baud}...")
-        self.con = Serial(
-            str(self.path.absolute()), baudrate=self.baud, timeout=self.timeout
+        path = str(self._path.absolute())
+        logger.debug(f"opening serial port {path!r} with baud {self._baud}...")
+        self._con = Serial(
+            str(self._path.absolute()), baudrate=self._baud, timeout=self._timeout
         )
         logger.trace("opened serial port.")
         return self
@@ -54,9 +54,9 @@ class Interface(AbstractContextManager):
         __exc_value: Optional[BaseException],
         __traceback: Optional[TracebackType],
     ) -> Optional[bool]:
-        if self.con:
+        if self._con:
             logger.trace("closing serial port...")
-            self.con.close()
+            self._con.close()
             logger.trace("serial port closed.")
 
         return super().__exit__(__exc_type, __exc_value, __traceback)
@@ -66,9 +66,9 @@ class Interface(AbstractContextManager):
         request = RequestPacket(kind=0)
         payload = bytes(request)
         logger.debug(f"sending request {request!r} [{payload!r}]...")
-        self.con.write(payload)
+        self._con.write(payload)
         logger.debug("awaiting response...")
-        response_bytes = self.con.read_until(b"\x00")
+        response_bytes = self._con.read_until(b"\x00")
         logger.debug(f"received device response := {response_bytes!r}")
         response = TelemetryPacket.from_bytes(response_bytes + b"\x00")
         logger.debug(f"received response {response!r}")

--- a/turret_python_interface/interface.py
+++ b/turret_python_interface/interface.py
@@ -16,6 +16,7 @@ class Interface(AbstractContextManager):
 
     def __init__(
         self,
+        *,  # disallow positional arguments.
         serial_path: Path = Path("/") / "dev" / "ttyS0",
         baud: int = 115200,
         timeout=30,

--- a/turret_python_interface/mock_interface.py
+++ b/turret_python_interface/mock_interface.py
@@ -3,7 +3,7 @@ Provides a mock Interface class for testing purposes, to decouple tests from req
 the entire turret hardware stack.
 """
 
-from math import tau
+from math import tau, pi, sin
 from pathlib import Path
 from types import TracebackType
 from typing import Optional, Type
@@ -14,10 +14,18 @@ from .telemetry_packet import TelemetryPacket
 
 class MockInterface(Interface):
     # noinspection PyMissingConstructor
-    def __init__(self, **kwargs):
-        # note: we intentionally don't call the constructor of the superclass as it would
+    def __init__(
+        self,
+        *,
+        serial_path: Path = Path("/") / "dev" / "ttyS0",
+        baud: int = 115200,
+        timeout=30,
+    ):
+        # NOTE: we intentionally don't call the constructor of the superclass as it would
         #       init a serial connection; which is an implementation detail
         #       and we cannot mock it effectively.
+        # NOTE: the internal data members of this type are not mocked, as they are implementation
+        #       details.  mocking them is unnecessary.
         self.t = 0
         ...
 
@@ -25,14 +33,21 @@ class MockInterface(Interface):
     def state(self) -> float:
         # basically, we are reproducing a sine wave.
         # Every time the state is observed, time progresses.
-        self.t += pi/4
-        return sin((self.t - pi/4) / tau)
+        self.t += pi / 4
+        if self.t >= tau:
+            self.t = 0
+
+        return sin(self.t - pi / 4)
 
     def __enter__(self) -> Interface:
         ...
 
-    def __exit__(self, __exc_type: Optional[Type[BaseException]], __exc_value: Optional[BaseException],
-                 __traceback: Optional[TracebackType]) -> Optional[bool]:
+    def __exit__(
+        self,
+        __exc_type: Optional[Type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
         ...
 
     def get_telemetry(self) -> TelemetryPacket:

--- a/turret_python_interface/mock_interface.py
+++ b/turret_python_interface/mock_interface.py
@@ -1,0 +1,39 @@
+"""
+Provides a mock Interface class for testing purposes, to decouple tests from requiring
+the entire turret hardware stack.
+"""
+
+from math import tau
+from pathlib import Path
+from types import TracebackType
+from typing import Optional, Type
+
+from .interface import Interface
+from .telemetry_packet import TelemetryPacket
+
+
+class MockInterface(Interface):
+    # noinspection PyMissingConstructor
+    def __init__(self, **kwargs):
+        # note: we intentionally don't call the constructor of the superclass as it would
+        #       init a serial connection; which is an implementation detail
+        #       and we cannot mock it effectively.
+        self.t = 0
+        ...
+
+    @property
+    def state(self) -> float:
+        # basically, we are reproducing a sine wave.
+        # Every time the state is observed, time progresses.
+        self.t += pi/4
+        return sin((self.t - pi/4) / tau)
+
+    def __enter__(self) -> Interface:
+        ...
+
+    def __exit__(self, __exc_type: Optional[Type[BaseException]], __exc_value: Optional[BaseException],
+                 __traceback: Optional[TracebackType]) -> Optional[bool]:
+        ...
+
+    def get_telemetry(self) -> TelemetryPacket:
+        return TelemetryPacket(turret_pos=self.state)

--- a/turret_python_interface/mock_interface.py
+++ b/turret_python_interface/mock_interface.py
@@ -33,11 +33,15 @@ class MockInterface(Interface):
     def state(self) -> float:
         # basically, we are reproducing a sine wave.
         # Every time the state is observed, time progresses.
+
+        # preserve the current time
+        t = self.t
+        # increment t for the next tick
         self.t += pi / 4
         if self.t >= tau:
             self.t = 0
 
-        return sin(self.t - pi / 4)
+        return sin(t)
 
     def __enter__(self) -> Interface:
         ...


### PR DESCRIPTION
this PR adds a mock interface to facilitate testing of downstream code without access to the actual hardware.
This can facilitate testing in downstream libraries such as the ROS2 turret wrapper.

It shares the same outward interface as the `Interface` class it inherits, but does not connect to any external resources, and instead provides a mocked result when queried. This mock signal is a sine wave that increments in intervals of `pi/4`, matching the mathematical function `state(t) = sin(t)`. 