### PR TITLE
Implement QEI datamodel

### DIFF
--- a/tests/test_telemetry_packet.py
+++ b/tests/test_telemetry_packet.py
@@ -2,8 +2,8 @@ from turret_python_interface.datamodel.telemetry_packet import TelemetryPacket
 
 
 def test_decode():
-    raw = b"\x16\xa1jturret_pos\xfaBG\xfdqV\x14\xd0\x9d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    raw = b'\r\xa2jturret_pos\x18jturret_rotgForwardgM\x06\x10\x00'
     response = TelemetryPacket.from_bytes(raw)
 
     # can't compare floats by equality; but we know the value is ~50 since we provided the data.
-    assert round(response.turret_pos) == 50
+    assert round(response.turret_pos) == 0

--- a/turret_python_interface/datamodel/telemetry_packet.py
+++ b/turret_python_interface/datamodel/telemetry_packet.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from .message_base import MessageBase
+from enum import Enum
 
 import attr
+
+from .message_base import MessageBase
+
+
+class TurretDirection(Enum):
+    Forward = "Forward"
+    Backward = "Backward"
 
 
 @attr.dataclass
@@ -13,3 +20,4 @@ class TelemetryPacket(MessageBase):
     """
 
     turret_pos: float
+    turret_rot: TurretDirection


### PR DESCRIPTION
Implements the new `ResponsePacket` structure returned by the turret hardware

Caused by https://github.com/SC-Robotics-2021/osiris_hardware/issues/3
Links to https://github.com/SC-Robotics-2021/osiris_hardware/pull/4 https://github.com/SC-Robotics-2021/osiris_hardware/issues/1